### PR TITLE
Modify fetching git tag message in .github/workflows/main-release.yaml

### DIFF
--- a/.github/workflows/main-release.yaml
+++ b/.github/workflows/main-release.yaml
@@ -40,8 +40,8 @@ jobs:
       - name: Env
         id: vars
         run: |
-          echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-          echo "tag_msg=$(git tag -l --format='%(contents:subject)' ${GITHUB_REF#refs/*/})" >> $GITHUB_OUTPUT
+          echo "tag=${GITHUB_REF#refs/*/}"                                                                 >> $GITHUB_OUTPUT
+          echo "tag_msg=$(git cat-file -p "$(git describe --tags --abbrev=0)" | tail -n +6)"               >> $GITHUB_OUTPUT
 
       - name: Build
         run: |


### PR DESCRIPTION
# Release Info – GitHub Actions Workflow Update (2025-08-07)

This simple but effective refinement enhances the quality of release documentation and helps developers and users track versions more clearly.

## Summary

This update improves how the Git tag message is fetched in the `.github/workflows/main-release.yaml` file, resulting in more detailed and accurate release documentation.

## Background

- Previously, the workflow only retrieved the **first line** (subject) of the Git tag message using:

```bash
git tag -l --format='%(contents:subject)' ${GITHUB_REF#refs/*/}
```

- This caused the tag message in release materials to be brief and less informative.

## Fix

- The workflow now extracts the **full message** of the latest annotated Git tag by running:

```bash
echo "tag_msg=$(git cat-file -p "$(git describe --tags --abbrev=0)" | tail -n +6)" >> $GITHUB_OUTPUT
```

## Benefits

- Release artifacts such as `VERSION.md` now include the full, detailed Git tag message.
- Improves clarity and informativeness of release notes and documentation.
- Maintains existing release pipeline functionality with improved message extraction.

