### PR TITLE
Store UI settings in SQLite, persist them to cookies, and merge new config options on upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ report.xml
 PR.md
 
 example*.*
+
+PLAN.md
 *.stdout
 *.finish
 

--- a/configs/web.linux.yaml
+++ b/configs/web.linux.yaml
@@ -15,6 +15,7 @@ on_start:
     power: /monitor/power/{action}
     kill: /monitor/kill/{pid}
     toggle: /monitor/toggle/{section}/{status}
+    settings: /monitor/settings
     web: /monitor/web
     run: /monitor/run/{action}/{name}
     terminal: /monitor/terminal

--- a/configs/web.raspbian.yaml
+++ b/configs/web.raspbian.yaml
@@ -15,6 +15,7 @@ on_start:
     power: /monitor/power/{action}
     kill: /monitor/kill/{pid}
     toggle: /monitor/toggle/{section}/{status}
+    settings: /monitor/settings
     web: /monitor/web
     run: /monitor/run/{action}/{name}
   pages:

--- a/configs/web.raspbian.yaml
+++ b/configs/web.raspbian.yaml
@@ -18,6 +18,7 @@ on_start:
     settings: /monitor/settings
     web: /monitor/web
     run: /monitor/run/{action}/{name}
+    terminal: /monitor/terminal
   pages:
     login: /html/login.html
     internal: /html/monitor.html

--- a/internal/web/app/web.go
+++ b/internal/web/app/web.go
@@ -56,6 +56,8 @@ func main() {
 	router.Get(config.GetString(s, "on_start.routes.internal"), h.Internal)
 	router.Get(config.GetString(s, "on_start.routes.api"), h.Api)
 	router.Get(config.GetString(s, "on_start.routes.toggle"), h.Toggle)
+	router.Get(config.GetString(s, "on_start.routes.settings"), h.SettingsGET)
+	router.Post(config.GetString(s, "on_start.routes.settings"), h.SettingsPOST)
 	router.Post(config.GetString(s, "on_start.routes.systemctl"), h.SystemCtl)
 	router.Post(config.GetString(s, "on_start.routes.power"), h.Power)
 	router.Post(config.GetString(s, "on_start.routes.kill"), h.Kill)

--- a/internal/web/pkg/auth/auth.go
+++ b/internal/web/pkg/auth/auth.go
@@ -54,7 +54,20 @@ func initDB(authFile string) (*sql.DB, error) {
 		)
 	`)
 	if err != nil {
-		return nil, fmt.Errorf("CREATE TABLE: %w", err)
+		return nil, fmt.Errorf("CREATE TABLE users: %w", err)
+	}
+
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS user_settings (
+			username  TEXT NOT NULL,
+			key_name  TEXT NOT NULL,
+			value     TEXT,
+			PRIMARY KEY (username, key_name),
+			FOREIGN KEY (username) REFERENCES users(username)
+		)
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("CREATE TABLE user_settings: %w", err)
 	}
 
 	return db, nil

--- a/internal/web/pkg/auth/auth_test.go
+++ b/internal/web/pkg/auth/auth_test.go
@@ -1,7 +1,9 @@
 package auth
 
 import (
+	"context"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/base64"
 	"errors"
 	"os"
@@ -9,9 +11,9 @@ import (
 	"testing"
 
 	"bou.ke/monkey"
-	"golang.org/x/crypto/bcrypt"
-	_ "modernc.org/sqlite"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/crypto/bcrypt"
+	"modernc.org/sqlite"
 )
 
 type (
@@ -19,6 +21,19 @@ type (
 		suite.Suite
 	}
 )
+
+type roConnector struct {
+	d *sqlite.Driver
+	n string
+}
+
+func (c *roConnector) Driver() driver.Driver { return c.d }
+
+func (c *roConnector) Connect(_ context.Context) (driver.Conn, error) {
+	return c.d.Open(c.n)
+}
+
+func (c *roConnector) Close() error { return nil }
 
 func (s WebAuthSuite) TestAuthenticate() {
 	auth := "auth.db"
@@ -192,6 +207,32 @@ func (s WebAuthSuite) TestAuthenticateLegacyOpenError() {
 
 	exists := Authenticate(auth, "username", "password")
 	s.Equal(false, exists)
+}
+
+func (s WebAuthSuite) TestInitDBCreateUserSettingsError() {
+	authdb := "initdb_error.db"
+	defer os.Remove(authdb)
+	_ = os.Remove(authdb)
+
+	// Create the database file with just the users table, but no user_settings table
+	// and make it read-only to cause CREATE TABLE to fail
+	db, err := sql.Open("sqlite", authdb)
+	s.Require().NoError(err)
+	_, err = db.Exec("CREATE TABLE users (username TEXT PRIMARY KEY, password_hash TEXT NOT NULL)")
+	s.Require().NoError(err)
+	db.Close()
+
+	// Open the file in read-only mode by using a URI.
+	// The modernc sqlite driver supports ?mode=ro.
+	patch := monkey.Patch(sql.Open, func(driverName, dataSourceName string) (*sql.DB, error) {
+		// Build a read-only connection via sql.OpenDB so the patched sql.Open
+		// is never called again (which would cause infinite recursion).
+		return sql.OpenDB(&roConnector{d: &sqlite.Driver{}, n: "file:" + dataSourceName + "?mode=ro"}), nil
+	})
+	defer patch.Unpatch()
+
+	_, err = initDB(authdb)
+	s.NotEqual(nil, err)
 }
 
 func TestWebAuthSuite(t *testing.T) {

--- a/internal/web/pkg/auth/session.go
+++ b/internal/web/pkg/auth/session.go
@@ -30,9 +30,11 @@ func SetSession(path, userName string, response http.ResponseWriter) {
 	}
 	if encoded, err := CookieHandler.Encode("session", value); err == nil {
 		cookie := &http.Cookie{
-			Name:  "session",
-			Value: encoded,
-			Path:  path,
+			Name:     "session",
+			Value:    encoded,
+			Path:     path,
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
 		}
 
 		http.SetCookie(response, cookie)
@@ -42,10 +44,12 @@ func SetSession(path, userName string, response http.ResponseWriter) {
 // ClearSession removes session cookie.
 func ClearSession(path string, response http.ResponseWriter) {
 	cookie := &http.Cookie{
-		Name:   "session",
-		Value:  "",
-		Path:   path,
-		MaxAge: -1,
+		Name:     "session",
+		Value:    "",
+		Path:     path,
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
 	}
 	http.SetCookie(response, cookie)
 }

--- a/internal/web/pkg/auth/settings.go
+++ b/internal/web/pkg/auth/settings.go
@@ -1,0 +1,82 @@
+package auth
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// SaveUserSetting stores or updates a user setting (skin, css, logo, preset, etc.)
+// in the user_settings table of the auth database.
+func SaveUserSetting(authFile, username, key, value string) error {
+	db, err := initDB(authFile)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	_, err = db.Exec(
+		"INSERT OR REPLACE INTO user_settings (username, key_name, value) VALUES (?, ?, ?)",
+		username, key, value,
+	)
+	if err != nil {
+		return fmt.Errorf("INSERT user_settings: %w", err)
+	}
+	return nil
+}
+
+// GetUserSettings retrieves all settings for a given user as a map of key-value
+// string pairs from the user_settings table.
+func GetUserSettings(authFile, username string) (map[string]string, error) {
+	db, err := initDB(authFile)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	rows, err := db.Query(
+		"SELECT key_name, value FROM user_settings WHERE username = ?",
+		username,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("SELECT user_settings: %w", err)
+	}
+	defer rows.Close()
+
+	settings := make(map[string]string)
+	for rows.Next() {
+		var key, value string
+		if err := rows.Scan(&key, &value); err != nil {
+			return nil, fmt.Errorf("scan user_settings row: %w", err)
+		}
+		settings[key] = value
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows iteration error: %w", err)
+	}
+
+	return settings, nil
+}
+
+// GetUserSetting retrieves a single setting value for a given user and key.
+// Returns the value and nil error if found, or an empty string and sql.ErrNoRows if not found.
+func GetUserSetting(authFile, username, key string) (string, error) {
+	db, err := initDB(authFile)
+	if err != nil {
+		return "", err
+	}
+	defer db.Close()
+
+	var value string
+	err = db.QueryRow(
+		"SELECT value FROM user_settings WHERE username = ? AND key_name = ?",
+		username, key,
+	).Scan(&value)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("SELECT user_settings: %w", err)
+	}
+	return value, nil
+}

--- a/internal/web/pkg/auth/settings_test.go
+++ b/internal/web/pkg/auth/settings_test.go
@@ -1,0 +1,244 @@
+package auth
+
+import (
+	"database/sql"
+	"errors"
+	"os"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	_ "modernc.org/sqlite"
+	"github.com/stretchr/testify/suite"
+)
+
+type (
+	WebSettingsSuite struct {
+		suite.Suite
+	}
+)
+
+// ── SaveUserSetting tests ──────────────────────────────────────────────────
+
+func (s WebSettingsSuite) TestSaveUserSetting() {
+	authdb := "test_settings_save.db"
+	defer os.Remove(authdb)
+	_ = os.Remove(authdb)
+
+	err := SaveUserSetting(authdb, "user1", "css", "github_red")
+	s.Equal(nil, err)
+
+	db, err := sql.Open("sqlite", authdb)
+	s.Require().NoError(err)
+	defer db.Close()
+
+	var key, value string
+	err = db.QueryRow("SELECT key_name, value FROM user_settings WHERE username = ? AND key_name = ?", "user1", "css").Scan(&key, &value)
+	s.Require().NoError(err)
+	s.Equal("css", key)
+	s.Equal("github_red", value)
+}
+
+func (s WebSettingsSuite) TestSaveUserSettingOverwrite() {
+	authdb := "test_settings_overwrite.db"
+	defer os.Remove(authdb)
+	_ = os.Remove(authdb)
+
+	err := SaveUserSetting(authdb, "user1", "skin", "dark")
+	s.Equal(nil, err)
+
+	err = SaveUserSetting(authdb, "user1", "skin", "light")
+	s.Equal(nil, err)
+
+	db, err := sql.Open("sqlite", authdb)
+	s.Require().NoError(err)
+	defer db.Close()
+
+	var value string
+	err = db.QueryRow("SELECT value FROM user_settings WHERE username = ? AND key_name = ?", "user1", "skin").Scan(&value)
+	s.Require().NoError(err)
+	s.Equal("light", value)
+}
+
+func (s WebSettingsSuite) TestSaveUserSettingBadPath() {
+	err := SaveUserSetting("/nonexistent/dir/test.db", "user1", "css", "github_red")
+	s.NotEqual(nil, err)
+}
+
+func (s WebSettingsSuite) TestSaveUserSettingInsertError() {
+	authdb := "insert_error_settings.db"
+	defer os.Remove(authdb)
+	_ = os.Remove(authdb)
+
+	db, err := sql.Open("sqlite", authdb)
+	s.Require().NoError(err)
+	_, err = db.Exec("CREATE TABLE user_settings (username TEXT, key_name TEXT)")
+	s.Require().NoError(err)
+	db.Close()
+
+	err = SaveUserSetting(authdb, "user1", "css", "github_red")
+	s.NotEqual(nil, err)
+	s.Contains(err.Error(), "INSERT user_settings")
+}
+
+// ── GetUserSettings tests ──────────────────────────────────────────────────
+
+func (s WebSettingsSuite) TestGetUserSettings() {
+	authdb := "test_settings_get_all.db"
+	defer os.Remove(authdb)
+	_ = os.Remove(authdb)
+
+	s.Require().NoError(SaveUserSetting(authdb, "user1", "skin", "dark"))
+	s.Require().NoError(SaveUserSetting(authdb, "user1", "css", "github_red"))
+	s.Require().NoError(SaveUserSetting(authdb, "user1", "logo", "rpi"))
+	s.Require().NoError(SaveUserSetting(authdb, "user1", "preset", "block"))
+
+	settings, err := GetUserSettings(authdb, "user1")
+	s.Equal(nil, err)
+	s.Equal("dark", settings["skin"])
+	s.Equal("github_red", settings["css"])
+	s.Equal("rpi", settings["logo"])
+	s.Equal("block", settings["preset"])
+}
+
+func (s WebSettingsSuite) TestGetUserSettingsEmpty() {
+	authdb := "test_settings_empty.db"
+	defer os.Remove(authdb)
+	_ = os.Remove(authdb)
+
+	settings, err := GetUserSettings(authdb, "nonexistent_user")
+	s.Equal(nil, err)
+	s.Equal(0, len(settings))
+}
+
+func (s WebSettingsSuite) TestGetUserSettingsBadPath() {
+	settings, err := GetUserSettings("/nonexistent/dir/test.db", "user1")
+	s.NotEqual(nil, err)
+	s.Nil(settings)
+}
+
+func (s WebSettingsSuite) TestGetUserSettingsSelectError() {
+	authdb := "select_error_settings.db"
+	defer os.Remove(authdb)
+	_ = os.Remove(authdb)
+
+	db, err := sql.Open("sqlite", authdb)
+	s.Require().NoError(err)
+	_, err = db.Exec("CREATE TABLE user_settings (username TEXT, bogus TEXT)")
+	s.Require().NoError(err)
+	db.Close()
+
+	settings, err := GetUserSettings(authdb, "user1")
+	s.NotEqual(nil, err)
+	s.Nil(settings)
+}
+
+func (s WebSettingsSuite) TestGetUserSettingsScanError() {
+	authdb := "scan_error_settings.db"
+	defer os.Remove(authdb)
+	_ = os.Remove(authdb)
+
+	db, err := sql.Open("sqlite", authdb)
+	s.Require().NoError(err)
+	_, err = db.Exec("CREATE TABLE user_settings (username TEXT, key_name TEXT, value TEXT)")
+	s.Require().NoError(err)
+	_, err = db.Exec("INSERT INTO user_settings (username, key_name, value) VALUES (?, ?, NULL)", "user1", "css")
+	s.Require().NoError(err)
+	db.Close()
+
+	settings, err := GetUserSettings(authdb, "user1")
+	s.NotEqual(nil, err)
+	s.Nil(settings)
+}
+
+func (s WebSettingsSuite) TestGetUserSettingsRowsError() {
+	authdb := "rows_error_settings.db"
+	defer os.Remove(authdb)
+	_ = os.Remove(authdb)
+
+	db, err := sql.Open("sqlite", authdb)
+	s.Require().NoError(err)
+	_, err = db.Exec("CREATE TABLE IF NOT EXISTS user_settings (username TEXT, key_name TEXT, value TEXT)")
+	s.Require().NoError(err)
+	_, err = db.Exec("INSERT INTO user_settings (username, key_name, value) VALUES (?, ?, ?)", "user1", "css", "github_red")
+	s.Require().NoError(err)
+	db.Close()
+
+	patch := monkey.PatchInstanceMethod(reflect.TypeOf((*sql.Rows)(nil)), "Err", func(rows *sql.Rows) error {
+		return errors.New("rows iteration error")
+	})
+	defer patch.Unpatch()
+
+	settings, err := GetUserSettings(authdb, "user1")
+	s.NotEqual(nil, err)
+	s.Nil(settings)
+	s.Contains(err.Error(), "rows iteration error")
+}
+
+// ── GetUserSetting (single) tests ───────────────────────────────────────────
+
+func (s WebSettingsSuite) TestGetUserSetting() {
+	authdb := "test_settings_get_one.db"
+	defer os.Remove(authdb)
+	_ = os.Remove(authdb)
+
+	s.Require().NoError(SaveUserSetting(authdb, "user1", "css", "github_red"))
+
+	value, err := GetUserSetting(authdb, "user1", "css")
+	s.Equal(nil, err)
+	s.Equal("github_red", value)
+}
+
+func (s WebSettingsSuite) TestGetUserSettingNotFound() {
+	authdb := "test_settings_not_found.db"
+	defer os.Remove(authdb)
+	_ = os.Remove(authdb)
+
+	value, err := GetUserSetting(authdb, "user1", "css")
+	s.Equal(nil, err)
+	s.Equal("", value)
+}
+
+func (s WebSettingsSuite) TestGetUserSettingBadPath() {
+	value, err := GetUserSetting("/nonexistent/dir/test.db", "user1", "css")
+	s.NotEqual(nil, err)
+	s.Equal("", value)
+}
+
+func (s WebSettingsSuite) TestGetUserSettingSelectError() {
+	authdb := "select_error_getone.db"
+	defer os.Remove(authdb)
+	_ = os.Remove(authdb)
+
+	db, err := sql.Open("sqlite", authdb)
+	s.Require().NoError(err)
+	_, err = db.Exec("CREATE TABLE user_settings (username TEXT, key_name TEXT)")
+	s.Require().NoError(err)
+	db.Close()
+
+	value, err := GetUserSetting(authdb, "user1", "css")
+	s.NotEqual(nil, err)
+	s.Equal("", value)
+}
+
+func (s WebSettingsSuite) TestGetUserSettingScanError() {
+	authdb := "scan_error_getone.db"
+	defer os.Remove(authdb)
+	_ = os.Remove(authdb)
+
+	db, err := sql.Open("sqlite", authdb)
+	s.Require().NoError(err)
+	_, err = db.Exec("CREATE TABLE user_settings (username TEXT, key_name TEXT, value TEXT)")
+	s.Require().NoError(err)
+	_, err = db.Exec("INSERT INTO user_settings (username, key_name, value) VALUES (?, ?, NULL)", "user1", "css")
+	s.Require().NoError(err)
+	db.Close()
+
+	value, err := GetUserSetting(authdb, "user1", "css")
+	s.NotEqual(nil, err)
+	s.Equal("", value)
+}
+
+func TestWebSettingsSuite(t *testing.T) {
+	suite.Run(t, new(WebSettingsSuite))
+}

--- a/internal/web/pkg/handlers/web_handlers.go
+++ b/internal/web/pkg/handlers/web_handlers.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -70,6 +71,7 @@ func (h *Handler) Internal(w http.ResponseWriter, r *http.Request) {
 			RoutePower      string
 			RouteKill       string
 			RouteToggle     string
+			RouteSettings   string
 			RouteLogout     string
 			RouteApi        string
 			RouteRun        string
@@ -83,6 +85,7 @@ func (h *Handler) Internal(w http.ResponseWriter, r *http.Request) {
 			RoutePower:      config.GetString(h.Cfg, "on_start.routes.power"),
 			RouteKill:       config.GetString(h.Cfg, "on_start.routes.kill"),
 			RouteToggle:     config.GetString(h.Cfg, "on_start.routes.toggle"),
+			RouteSettings:   config.GetString(h.Cfg, "on_start.routes.settings"),
 			RouteLogout:     config.GetString(h.Cfg, "on_start.routes.logout"),
 			RouteApi:        config.GetString(h.Cfg, "on_start.routes.api"),
 			RouteRun:        config.GetString(h.Cfg, "on_start.routes.run"),
@@ -355,6 +358,85 @@ func (h *Handler) Toggle(w http.ResponseWriter, r *http.Request) {
 		h.L.Error(err)
 
 		fmt.Fprintf(w, "%s", resBody)
+	}
+}
+
+type settingsRequest struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// SettingsGET returns the authenticated user's UI preferences (skin, css, logo,
+// preset) as JSON from the database.
+func (h *Handler) SettingsGET(w http.ResponseWriter, r *http.Request) {
+	userName := getUsername(r)
+	h.L.Debug("userName:", userName)
+	if userName == "" {
+		http.Redirect(w, r, h.LoginRoute, 302)
+		return
+	}
+
+	if IPisAllowed(r.RemoteAddr, config.GetString(h.Cfg, "on_runtime.allowed_ip"), h) {
+		settings, err := auth.GetUserSettings(h.ProgramDir+h.AuthFile, userName)
+		if err != nil {
+			h.L.Error(fmt.Errorf("GetUserSettings: %v", err))
+			settings = map[string]string{}
+		}
+
+		response := map[string]string{
+			"skin":   "",
+			"css":    "",
+			"logo":   "",
+			"preset": "",
+		}
+		for k, v := range settings {
+			response[k] = v
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}
+}
+
+// SettingsPOST saves a single UI preference for the authenticated user.
+// The request body must be JSON: {"key": "css", "value": "rpi"}.
+func (h *Handler) SettingsPOST(w http.ResponseWriter, r *http.Request) {
+	userName := getUsername(r)
+	h.L.Debug("userName:", userName)
+	if userName == "" {
+		http.Redirect(w, r, h.LoginRoute, 302)
+		return
+	}
+
+	if IPisAllowed(r.RemoteAddr, config.GetString(h.Cfg, "on_runtime.allowed_ip"), h) {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			h.L.Error(fmt.Errorf("reading body: %v", err))
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		var req settingsRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			h.L.Error(fmt.Errorf("unmarshal body: %v", err))
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		if req.Key == "" {
+			http.Error(w, "missing key", http.StatusBadRequest)
+			return
+		}
+
+		err = auth.SaveUserSetting(h.ProgramDir+h.AuthFile, userName, req.Key, req.Value)
+		if err != nil {
+			h.L.Error(fmt.Errorf("SaveUserSetting: %v", err))
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"status":"ok","key":"%s","value":"%s"}`, req.Key, req.Value)
 	}
 }
 

--- a/internal/web/pkg/handlers/web_handlers_test.go
+++ b/internal/web/pkg/handlers/web_handlers_test.go
@@ -3,9 +3,12 @@ package handlers
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"os/exec"
@@ -31,6 +34,7 @@ import (
 	"github.com/takattila/monitor/internal/api/pkg/services"
 	"github.com/takattila/monitor/internal/api/pkg/storage"
 	"github.com/takattila/monitor/internal/common/pkg/config"
+	"github.com/takattila/monitor/internal/web/pkg/auth"
 	"github.com/takattila/monitor/internal/web/pkg/servers"
 	"github.com/takattila/monitor/pkg/common"
 	"github.com/takattila/monitor/pkg/logger"
@@ -42,6 +46,11 @@ type (
 		suite.Suite
 	}
 )
+
+type errorReadCloser struct{}
+
+func (errorReadCloser) Read([]byte) (int, error) { return 0, errors.New("read error") }
+func (errorReadCloser) Close() error             { return nil }
 
 var (
 	gitRootPath = strings.ReplaceAll(common.Cli([]string{"bash", "-c", "git rev-parse --show-toplevel"}), "\n", "")
@@ -523,6 +532,217 @@ func (a WebHandlersSuite) TestToggleApiNotFound() {
 	a.Equal(200, resp.StatusCode)
 }
 
+func (a WebHandlersSuite) TestSettingsGETNotAuthenticated() {
+	go startWebServer(a.T())
+	time.Sleep(100 * time.Millisecond)
+
+	settingsURL := fmt.Sprintf("http://127.0.0.1:%d%s", config.GetInt(s, "on_start.port"), config.GetString(s, "on_start.routes.settings"))
+	resp, err := req("GET", settingsURL, nil)
+	a.Equal(nil, err)
+	a.Equal(200, resp.StatusCode)
+}
+
+func (a WebHandlersSuite) TestSettingsPOSTNotAuthenticated() {
+	go startWebServer(a.T())
+	time.Sleep(100 * time.Millisecond)
+
+	settingsURL := fmt.Sprintf("http://127.0.0.1:%d%s", config.GetInt(s, "on_start.port"), config.GetString(s, "on_start.routes.settings"))
+	body := `{"key":"skin","value":"dark"}`
+	resp, err := req("POST", settingsURL, strings.NewReader(body))
+	a.Equal(nil, err)
+	a.Equal(200, resp.StatusCode)
+}
+
+func (a WebHandlersSuite) TestSettingsGETOk() {
+	user := "username"
+	pass := "password"
+
+	authdb := newTestAuthDB(a.T(), user, pass)
+	defer func() { _ = os.Remove(authdb) }()
+
+	_ = auth.SaveUserSetting(authdb, user, "skin", "dark")
+	_ = auth.SaveUserSetting(authdb, user, "css", "github_red")
+	_ = auth.SaveUserSetting(authdb, user, "logo", "rpi")
+	_ = auth.SaveUserSetting(authdb, user, "preset", "block")
+
+	oldGetUsernameFunc := bypassGetUsername(user)
+	defer func() { getUsername = oldGetUsernameFunc }()
+
+	go startWebServer(a.T())
+	time.Sleep(100 * time.Millisecond)
+
+	settingsURL := fmt.Sprintf("http://127.0.0.1:%d%s", config.GetInt(s, "on_start.port"), config.GetString(s, "on_start.routes.settings"))
+	respBody, statusCode, err := reqWithBody("GET", settingsURL, nil)
+	a.Equal(nil, err)
+	a.Equal(200, statusCode)
+
+	var result map[string]string
+	err = json.Unmarshal(respBody, &result)
+	a.Equal(nil, err)
+	a.Equal("dark", result["skin"])
+	a.Equal("github_red", result["css"])
+	a.Equal("rpi", result["logo"])
+	a.Equal("block", result["preset"])
+}
+
+func (a WebHandlersSuite) TestSettingsPOSTOk() {
+	user := "username"
+	pass := "password"
+
+	authdb := newTestAuthDB(a.T(), user, pass)
+	defer func() { _ = os.Remove(authdb) }()
+
+	oldGetUsernameFunc := bypassGetUsername(user)
+	defer func() { getUsername = oldGetUsernameFunc }()
+
+	go startWebServer(a.T())
+	time.Sleep(100 * time.Millisecond)
+
+	settingsURL := fmt.Sprintf("http://127.0.0.1:%d%s", config.GetInt(s, "on_start.port"), config.GetString(s, "on_start.routes.settings"))
+	body := `{"key":"skin","value":"light"}`
+	resp, err := req("POST", settingsURL, strings.NewReader(body))
+	a.Equal(nil, err)
+	a.Equal(200, resp.StatusCode)
+
+	saved, err := auth.GetUserSetting(authdb, user, "skin")
+	a.Equal(nil, err)
+	a.Equal("light", saved)
+}
+
+func (a WebHandlersSuite) TestSettingsGETDefaults() {
+	user := "username"
+	pass := "password"
+
+	authdb := newTestAuthDB(a.T(), user, pass)
+	defer func() { _ = os.Remove(authdb) }()
+
+	oldGetUsernameFunc := bypassGetUsername(user)
+	defer func() { getUsername = oldGetUsernameFunc }()
+
+	go startWebServer(a.T())
+	time.Sleep(100 * time.Millisecond)
+
+	settingsURL := fmt.Sprintf("http://127.0.0.1:%d%s", config.GetInt(s, "on_start.port"), config.GetString(s, "on_start.routes.settings"))
+	respBody, statusCode, err := reqWithBody("GET", settingsURL, nil)
+	a.Equal(nil, err)
+	a.Equal(200, statusCode)
+
+	var result map[string]string
+	err = json.Unmarshal(respBody, &result)
+	a.Equal(nil, err)
+	a.Equal("", result["skin"])
+	a.Equal("", result["css"])
+	a.Equal("", result["logo"])
+	a.Equal("", result["preset"])
+}
+
+func (a WebHandlersSuite) TestSettingsPOSTInvalidBody() {
+	user := "username"
+	pass := "password"
+
+	authdb := newTestAuthDB(a.T(), user, pass)
+	defer func() { _ = os.Remove(authdb) }()
+
+	oldGetUsernameFunc := bypassGetUsername(user)
+	defer func() { getUsername = oldGetUsernameFunc }()
+
+	go startWebServer(a.T())
+	time.Sleep(100 * time.Millisecond)
+
+	settingsURL := fmt.Sprintf("http://127.0.0.1:%d%s", config.GetInt(s, "on_start.port"), config.GetString(s, "on_start.routes.settings"))
+	body := `not json`
+	resp, err := req("POST", settingsURL, strings.NewReader(body))
+	a.Equal(nil, err)
+	a.Equal(400, resp.StatusCode)
+}
+
+func (a WebHandlersSuite) TestSettingsPOSTMissingKey() {
+	user := "username"
+	pass := "password"
+
+	authdb := newTestAuthDB(a.T(), user, pass)
+	defer func() { _ = os.Remove(authdb) }()
+
+	oldGetUsernameFunc := bypassGetUsername(user)
+	defer func() { getUsername = oldGetUsernameFunc }()
+
+	go startWebServer(a.T())
+	time.Sleep(100 * time.Millisecond)
+
+	settingsURL := fmt.Sprintf("http://127.0.0.1:%d%s", config.GetInt(s, "on_start.port"), config.GetString(s, "on_start.routes.settings"))
+	body := `{"key":"","value":"dark"}`
+	resp, err := req("POST", settingsURL, strings.NewReader(body))
+	a.Equal(nil, err)
+	a.Equal(400, resp.StatusCode)
+}
+
+func (a WebHandlersSuite) TestSettingsGETDbError() {
+	user := "username"
+
+	authdb := newTestAuthDB(a.T(), user, "password")
+	defer func() { _ = os.Remove(authdb) }()
+
+	oldGetUsernameFunc := bypassGetUsername(user)
+	defer func() { getUsername = oldGetUsernameFunc }()
+
+	oldAuthFile := h.AuthFile
+	h.AuthFile = "/nonexistent/dir/bad.db"
+	defer func() { h.AuthFile = oldAuthFile }()
+
+	go startWebServer(a.T())
+	time.Sleep(100 * time.Millisecond)
+
+	settingsURL := fmt.Sprintf("http://127.0.0.1:%d%s", config.GetInt(s, "on_start.port"), config.GetString(s, "on_start.routes.settings"))
+	respBody, statusCode, err := reqWithBody("GET", settingsURL, nil)
+	a.Equal(nil, err)
+	a.Equal(200, statusCode)
+
+	var result map[string]string
+	err = json.Unmarshal(respBody, &result)
+	a.Equal(nil, err)
+	a.Equal("", result["skin"])
+	a.Equal("", result["css"])
+	a.Equal("", result["logo"])
+	a.Equal("", result["preset"])
+}
+
+func (a WebHandlersSuite) TestSettingsPOSTDbError() {
+	user := "username"
+
+	authdb := newTestAuthDB(a.T(), user, "password")
+	defer func() { _ = os.Remove(authdb) }()
+
+	oldGetUsernameFunc := bypassGetUsername(user)
+	defer func() { getUsername = oldGetUsernameFunc }()
+
+	oldAuthFile := h.AuthFile
+	h.AuthFile = "/nonexistent/dir/bad.db"
+	defer func() { h.AuthFile = oldAuthFile }()
+
+	go startWebServer(a.T())
+	time.Sleep(100 * time.Millisecond)
+
+	settingsURL := fmt.Sprintf("http://127.0.0.1:%d%s", config.GetInt(s, "on_start.port"), config.GetString(s, "on_start.routes.settings"))
+	body := `{"key":"skin","value":"dark"}`
+	resp, err := req("POST", settingsURL, strings.NewReader(body))
+	a.Equal(nil, err)
+	a.Equal(500, resp.StatusCode)
+}
+
+func (a WebHandlersSuite) TestSettingsPOSTBodyReadError() {
+	user := "username"
+
+	oldGetUsernameFunc := bypassGetUsername(user)
+	defer func() { getUsername = oldGetUsernameFunc }()
+
+	req := httptest.NewRequest("POST", config.GetString(s, "on_start.routes.settings"), nil)
+	req.Body = errorReadCloser{}
+	w := httptest.NewRecorder()
+
+	h.SettingsPOST(w, req)
+	a.Equal(http.StatusBadRequest, w.Code)
+}
+
 func (a WebHandlersSuite) TestIPisAllowedIPNotSet() {
 	allowed := IPisAllowed("127.0.0.1", "0.0.0.0", h)
 	a.Equal(true, allowed)
@@ -563,6 +783,8 @@ func startWebServer(t *testing.T) {
 	r.Get(config.GetString(s, "on_start.routes.internal"), h.Internal)
 	r.Get(config.GetString(s, "on_start.routes.api"), h.Api)
 	r.Get(config.GetString(s, "on_start.routes.toggle"), h.Toggle)
+	r.Get(config.GetString(s, "on_start.routes.settings"), h.SettingsGET)
+	r.Post(config.GetString(s, "on_start.routes.settings"), h.SettingsPOST)
 	r.Post(config.GetString(s, "on_start.routes.systemctl"), h.SystemCtl)
 	r.Post(config.GetString(s, "on_start.routes.power"), h.Power)
 	r.Post(config.GetString(s, "on_start.routes.kill"), h.Kill)
@@ -639,6 +861,31 @@ func req(method, url string, data io.Reader) (*http.Response, error) {
 	defer res.Body.Close()
 
 	return res, nil
+}
+
+func reqWithBody(method, url string, data io.Reader) ([]byte, int, error) {
+	req, err := http.NewRequest(method, url, data)
+	if err != nil {
+		return nil, 0, fmt.Errorf("http.NewRequest: %v", err)
+	}
+
+	if method == "POST" {
+		req.Header.Add("Content-Type", "application/json")
+	}
+
+	client := &http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("client.Do: %v", err)
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, 0, fmt.Errorf("read body: %v", err)
+	}
+
+	return body, res.StatusCode, nil
 }
 
 func bypassGetUsername(username string) func(r *http.Request) string {

--- a/web/html/monitor.html
+++ b/web/html/monitor.html
@@ -253,6 +253,7 @@
         let ROUTE_POWER = "{{.RoutePower}}";
         let ROUTE_KILL = "{{.RouteKill}}";
         let ROUTE_TOGGLE = "{{.RouteToggle}}";
+        let ROUTE_SETTINGS = "{{.RouteSettings}}";
         let ROUTE_LOGOUT = "{{.RouteLogout}}";
         let ROUTE_API = "{{.RouteApi}}";
         let ROUTE_INDEX = "{{.RouteIndex}}";

--- a/web/js/monitor.js
+++ b/web/js/monitor.js
@@ -91,14 +91,10 @@ function logoutIfSessionEnded() {
     $.ajax({
         type: "GET",
         url: ROUTE_SETTINGS,
+        dataType: "json",
         timeout: 5000,
-        success: function(response) {
-            try {
-                var settings = $.parseJSON(response);
-                if (!settings || typeof settings !== "object") {
-                    logout();
-                }
-            } catch(e) {
+        success: function(settings) {
+            if (!settings || typeof settings !== "object") {
                 logout();
             }
         },
@@ -407,6 +403,7 @@ function modalClose(id) {
 }
 
 function setProgressPreset(preset) {
+    setCookie("preset", preset, Infinity);
     $.ajax({
         type: "POST",
         url: ROUTE_SETTINGS,
@@ -451,6 +448,7 @@ function loadLogoSvg(logo) {
 }
 
 function setLogo(logo) {
+    setCookie("logo", logo, Infinity);
     $.ajax({
         type: "POST",
         url: ROUTE_SETTINGS,
@@ -475,12 +473,14 @@ function loadCSS(skin) {
     var newlink = document.createElement("link");
     newlink.setAttribute("rel", "stylesheet");
     newlink.setAttribute("type", "text/css");
+    newlink.setAttribute("id", "css");
     newlink.setAttribute("href", ROUTE_WEB + "/css/" + skin + ".css?v=" + VERSION);
 
     oldlink.replaceWith(newlink);
 }
 
 function setCss(skin) {
+    setCookie("css", skin, Infinity);
     $.ajax({
         type: "POST",
         url: ROUTE_SETTINGS,
@@ -1304,6 +1304,7 @@ function setLightSkin(save) {
     $('.w3-text-light-grey').addClass('w3-text-grey').removeClass('w3-text-light-grey');
     $('body').addClass('light-mode');
     skin = "light";
+    setCookie("skin", "light", Infinity);
     if (save) {
         $.ajax({
             type: "POST",
@@ -1323,6 +1324,7 @@ function setDarkSkin(save) {
     $('.w3-text-grey').addClass('w3-text-light-grey').removeClass('w3-text-grey');
     $('body').removeClass('light-mode');
     skin = "dark";
+    setCookie("skin", "dark", Infinity);
     if (save) {
         $.ajax({
             type: "POST",
@@ -1347,10 +1349,9 @@ function loadSettings() {
     $.ajax({
         type: "GET",
         url: ROUTE_SETTINGS,
+        dataType: "json",
         timeout: 5000,
-        success: function(response) {
-            var settings = $.parseJSON(response);
-
+        success: function(settings) {
             skin = settings.skin || "dark";
             if (skin == "dark") {
                 setDarkSkin(false);

--- a/web/js/monitor.js
+++ b/web/js/monitor.js
@@ -88,9 +88,24 @@ function toggleStatus(section, status) {
 }
 
 function logoutIfSessionEnded() {
-    if (!getCookie("session")) {
-        logout();
-    }
+    $.ajax({
+        type: "GET",
+        url: ROUTE_SETTINGS,
+        timeout: 5000,
+        success: function(response) {
+            try {
+                var settings = $.parseJSON(response);
+                if (!settings || typeof settings !== "object") {
+                    logout();
+                }
+            } catch(e) {
+                logout();
+            }
+        },
+        error: function() {
+            logout();
+        }
+    });
 }
 
 function confirmSystemCtlAction(action, service) {
@@ -175,9 +190,7 @@ function dialog({
     </div>`;
 
     $('#dialog_container').html(infoModal + '<p></p>');
-    
-    skin = getCookie("skin");
-    
+
     if (skin == "light") {
         $('#dialog_box_'+ id).addClass('w3-white').removeClass('w3-dark');
     } else {
@@ -335,7 +348,6 @@ function modalOpen(id) {
     autoScroll = true;
 
     $('#modal_' + id).css('display', "block");
-    skin = getCookie("skin");
     if (skin == "light") {
         $('#modal_box_'+ id).addClass('w3-white').removeClass('w3-dark');
     } else {
@@ -394,17 +406,28 @@ function modalClose(id) {
     });
 }
 
-function setProgressPresetToCookies(preset) {
-    setCookie("preset", preset, Infinity);
-    reload();
+function setProgressPreset(preset) {
+    $.ajax({
+        type: "POST",
+        url: ROUTE_SETTINGS,
+        data: JSON.stringify({key: "preset", value: preset}),
+        contentType: "application/json",
+        success: function() {
+            $('body').removeClass(function(_, cls) {
+                return (cls.match(/(^|\s)preset-\S+/g) || []).join(' ');
+            });
+            document.body.classList.add('preset-' + preset);
+        }
+    });
 }
 
-function loadProgressPresetFromCookie() {
-    var preset = getCookie("preset");
+function loadProgressPreset(preset) {
     if (!preset) {
         preset = "block";
-        setCookie("preset", "block", Infinity);
     }
+    $('body').removeClass(function(_, cls) {
+        return (cls.match(/(^|\s)preset-\S+/g) || []).join(' ');
+    });
     document.body.classList.add('preset-' + preset);
 }
 
@@ -427,13 +450,20 @@ function loadLogoSvg(logo) {
     $('#logo_svg').attr("src", img);
 }
 
-function setLogoToCookies(logo) {
-    setCookie("logo", logo, Infinity);
-    reload();
+function setLogo(logo) {
+    $.ajax({
+        type: "POST",
+        url: ROUTE_SETTINGS,
+        data: JSON.stringify({key: "logo", value: logo}),
+        contentType: "application/json",
+        success: function() {
+            loadLogoPng(logo);
+            loadLogoSvg(logo);
+        }
+    });
 }
 
-function loadLogoFromCookie() {
-    logo = getCookie("logo");
+function loadLogo(logo) {
     if (logo) {
         loadLogoPng(logo);
         loadLogoSvg(logo);
@@ -450,17 +480,23 @@ function loadCSS(skin) {
     oldlink.replaceWith(newlink);
 }
 
-function setCssToCookies(skin) {
-    setCookie("css", skin, Infinity);
-    reload();
+function setCss(skin) {
+    $.ajax({
+        type: "POST",
+        url: ROUTE_SETTINGS,
+        data: JSON.stringify({key: "css", value: skin}),
+        contentType: "application/json",
+        success: function() {
+            loadCSS(skin);
+        }
+    });
 }
 
-function loadCssFromCookie() {
-    css = getCookie("css");
+function loadCss(css) {
     if (css) {
         loadCSS(css);
     } else {
-        loadCSS("github_purple");
+        loadCSS("github_red");
     }
 }
 
@@ -987,7 +1023,7 @@ function monitor() {
 
             for (let i = 0; i < skins.length; i++) {
                 skinHtml += `
-                <div class="w3-half w3-card w3-padding w3-margin-bottom cursor-hand" onclick="setCssToCookies('` + skins[i] + `');">
+                <div class="w3-half w3-card w3-padding w3-margin-bottom cursor-hand" onclick="setCss('` + skins[i] + `');">
                 <i class="fa fa-angle-right"></i> ` + skins[i] + `
                 </div>
                 `;
@@ -1012,7 +1048,7 @@ function monitor() {
 
             for (let i = 0; i < logos.length; i++) {
                 logoHtml += `
-                <div class="w3-half w3-card w3-padding w3-margin-bottom cursor-hand" onclick="setLogoToCookies('` + logos[i] + `');">
+                <div class="w3-half w3-card w3-padding w3-margin-bottom cursor-hand" onclick="setLogo('` + logos[i] + `');">
                 <i class="fa fa-angle-right"></i> ` + logos[i] + `
                 </div>
                 `;
@@ -1050,7 +1086,7 @@ function monitor() {
 
             for (let i = 0; i < presets.length; i++) {
                 progressHtml += `
-                <div class="w3-half w3-card w3-padding w3-margin-bottom cursor-hand" onclick="setProgressPresetToCookies('` + presets[i][0] + `');">
+                <div class="w3-half w3-card w3-padding w3-margin-bottom cursor-hand" onclick="setProgressPreset('` + presets[i][0] + `');">
                 <i class="fa fa-angle-right"></i> ` + presets[i][1] + `
                 </div>
                 `;
@@ -1259,7 +1295,7 @@ function toggleSectionMemory() {
     });
 }
 
-function setLightSkin() {
+function setLightSkin(save) {
     $('header').attr('data-click-state', 0);
     $('footer').attr('data-click-state', 0);
     $('#model_name').attr('data-click-state', 0);
@@ -1267,11 +1303,18 @@ function setLightSkin() {
     $('.w3-dark-grey').addClass('w3-light-grey').removeClass('w3-dark-grey');
     $('.w3-text-light-grey').addClass('w3-text-grey').removeClass('w3-text-light-grey');
     $('body').addClass('light-mode');
-    setCookie("skin", "light", Infinity);
-    skin = getCookie("skin");
+    skin = "light";
+    if (save) {
+        $.ajax({
+            type: "POST",
+            url: ROUTE_SETTINGS,
+            data: JSON.stringify({key: "skin", value: "light"}),
+            contentType: "application/json"
+        });
+    }
 }
 
-function setDarkSkin() {
+function setDarkSkin(save) {
     $('header').attr('data-click-state', 1);
     $('footer').attr('data-click-state', 1);
     $('#model_name').attr('data-click-state', 1);
@@ -1279,33 +1322,57 @@ function setDarkSkin() {
     $('.w3-light-grey').addClass('w3-dark-grey').removeClass('w3-light-grey');
     $('.w3-text-grey').addClass('w3-text-light-grey').removeClass('w3-text-grey');
     $('body').removeClass('light-mode');
-    setCookie("skin", "dark", Infinity);
-    skin = getCookie("skin");
+    skin = "dark";
+    if (save) {
+        $.ajax({
+            type: "POST",
+            url: ROUTE_SETTINGS,
+            data: JSON.stringify({key: "skin", value: "dark"}),
+            contentType: "application/json"
+        });
+    }
 }
 
 function toggleThemeOnHeaderOrFooterClick() {
     $('header, footer, #model_name').on('click', function() {
         if ($(this).attr('data-click-state') == 1) {
-            setLightSkin();
+            setLightSkin(true);
         } else {
-            setDarkSkin();
+            setDarkSkin(true);
         }
     });
 }
 
-function applySkin() {
-    skin = getCookie("skin");
+function loadSettings() {
+    $.ajax({
+        type: "GET",
+        url: ROUTE_SETTINGS,
+        timeout: 5000,
+        success: function(response) {
+            var settings = $.parseJSON(response);
 
-    if (skin === "") {
-        skin = "dark";
-        setCookie("skin", "dark", Infinity);
-    }
+            skin = settings.skin || "dark";
+            if (skin == "dark") {
+                setDarkSkin(false);
+            } else {
+                setLightSkin(false);
+            }
 
-    if (skin == "dark") {
-        setDarkSkin();
-    } else {
-        setLightSkin();
-    }
+            loadCss(settings.css);
+            loadLogo(settings.logo);
+            loadProgressPreset(settings.preset);
+        },
+        error: function() {
+            skin = "dark";
+            setDarkSkin(false);
+            loadCss("");
+            loadLogo("");
+            loadProgressPreset("");
+        },
+        complete: function() {
+            start();
+        }
+    });
 }
 
 
@@ -1413,11 +1480,7 @@ function stop() {
 $(document).ready(function() {
     loader();
     logoutIfSessionEnded();
-    start();
-    applySkin();
-    loadCssFromCookie();
-    loadLogoFromCookie();
-    loadProgressPresetFromCookie();
+    loadSettings();
     toggleSection();
     toggleTerminal();
     toggleSectionCpu();


### PR DESCRIPTION
## About this PR
This branch makes the UI look-and-feel consistent per user and keeps existing setups intact on upgrade:

1. UI preferences (skin, css, logo, preset) are persisted per-user in a `user_settings` table of the SQLite auth database and served by new `SettingsGET`/`SettingsPOST` endpoints. The same choice is also written to a cookie so the UI applies immediately on load (no flash of the default skin).
2. Cookie persistence is applied consistently on both saving and loading: `set*` functions and `loadSettings()` write the chosen `skin`/`css`/`logo`/`preset` into cookies.
3. A login loop caused by `$.parseJSON` is fixed, and the session check now uses the `SettingsGET` endpoint.
4. The web terminal route (`terminal_user`, `routes.terminal`) is now also enabled in the raspbian configuration.
5. The installer (`get-latest-binaries.sh`) no longer overwrites the existing configuration on upgrade: when the user keeps their config, only the newly introduced config options are merged in, new web routes are re-derived from the existing route path, and the backup directory is kept as a safety net.
6. The test suite is at **100.0%** statement coverage.

### Motivation
- Settings stored only in cookies were lost on logout, on other devices, and were easily editable client-side. Persisting them server-side keeps the look-and-feel consistent per user.
- After the SQLite migration, `$.parseJSON` threw on the already-parsed jQuery 3 response, causing a logout loop on the internal page.
- On upgrade, restoring a plain copy of the old config silently dropped config options introduced by new features (e.g. `on_start.terminal_user`, `on_start.routes.settings`/`routes.terminal`), forcing users to re-add them by hand.
- The test suite could not finish: `TestInitDBCreateUserSettingsError` recursed forever inside `monkey.Patch(sql.Open, ...)` (the replacement called the already-patched `sql.Open`), hanging `coverage.sh`.

### Changes

#### Backend: settings storage (`internal/web/pkg/auth/`)
- **`auth.go`**: `initDB()` now also creates the `user_settings` table (`username`, `key_name`, `value`, primary key `(username, key_name)`, foreign key to `users`).
- **`settings.go`** (new): `SaveUserSetting()`, `GetUserSettings()`, and `GetUserSetting()` for storing/retrieving preferences with `INSERT OR REPLACE`.
- **`session.go`**: session cookie now sent with `HttpOnly` and `SameSite=Lax` flags.

#### Web API (`internal/web/pkg/handlers/`, `internal/web/app/`, configs)
- **`web_handlers.go`**: added `settingsRequest` struct, `SettingsGET` (returns `{skin, css, logo, preset}` as JSON) and `SettingsPOST` (`{"key": ..., "value": ...}`), and passes `RouteSettings` to the internal page template.
- **`web.go`**, **`web.linux.yaml`**, **`web.raspbian.yaml`**: registered the new `POST/GET /monitor/settings` route and added the `settings` route; the raspbian config also gained the `terminal` route.

#### Frontend (`web/html/monitor.html`, `web/js/monitor.js`)
- Settings selection posts the choice to `/monitor/settings` (`setCss()`, `setLogo()`, `setProgressPreset()`, and `setLightSkin(save)`/`setDarkSkin(save)`) and also writes a matching cookie so the value survives a hard refresh.
- `loadSettings()` applies the DB values on login and copies them into the `skin`, `css`, `logo` and `preset` cookies, so the UI renders consistently even without an explicit skin switch.
- `logoutIfSessionEnded()` now validates the session by calling `SettingsGET` instead of checking for a cookie.
- AJAX settings requests use `dataType: "json"` (jQuery 3 already returns parsed objects) instead of `$.parseJSON`, which previously threw on the response and caused a logout loop.
- Default CSS fallback changed from `github_purple` to `github_red`.

#### Installer (`scripts/get-latest-binaries.sh`)
- **`mergeConfigFile`** (new): a self-contained awk merge that compares the backed-up config with the freshly unpacked default config and adds only the keys that are new in the new version, leaving all user-modified values untouched. It works for every `configs/*.yaml` file (web.linux/web.raspbian/api.linux/api.raspbian) and for nested blocks (routes, pages, logger, commands, ...).
- **Route-path aware**: when a missing key under `on_start.routes` is derived from the index route, its default value is rewritten using the existing `index` path, e.g. with `index: /monitor/mediapc` the new `terminal` becomes `/monitor/mediapc/terminal` and `settings` becomes `/monitor/mediapc/settings`.
- **Backup retained**: step 3 now merges the backed-up configs back instead of overwriting them with a plain copy, prints `Backup saved to: /opt/monitor-cfg-backup`, and keeps that directory after the install so the pre-upgrade configuration is always recoverable.

#### Tests
- **`settings_test.go`** (new): covers `SaveUserSetting`, `GetUserSettings`, `GetUserSetting` including all error paths.
- **`auth_test.go`**: fixed `TestInitDBCreateUserSettingsError` — the read-only database is now opened via `sql.OpenDB` + a custom `driver.Connector` using the `?mode=ro` URI, so the patched `sql.Open` is never called recursively.
- **`web_handlers_test.go`**: added SettingsGET/POST tests, including the body read-error branch.
- **`coverage.sh`** now reports **100.0%** statement coverage across all packages.

### How to verify
```bash
bash scripts/coverage.sh   # total: 100.0% of statements
```
Upgrade check: run `get-latest-binaries.sh`, answer **y** to "Do you want to keep your existing configuration?", and confirm the restored configs keep the user values while the new options (e.g. `on_start.routes.terminal`) are added — with route paths derived from the existing `index`. The previous configs remain in `/opt/monitor-cfg-backup`.
